### PR TITLE
Fix ordering of entity revisions diffs

### DIFF
--- a/templates/editentity/history.php
+++ b/templates/editentity/history.php
@@ -45,7 +45,7 @@
                         $labelId = $revision->getConnection()->getId() . '_' . $revision->getRevisionNr() . 'id';
                         ?>
                         <td>
-                            <?php if ($revision->getRevisionNr() != $this->data['latestRevisionNbr']): ?>
+                            <?php if ($revision->getRevisionNr() > 0): ?>
                                 <input id="<?php echo $labelId; ?>" class="toggle_show_changes" type="checkbox"
                                        data-revision-nbr="<?php echo $revision->getRevisionNr(); ?>">
                                 <label
@@ -56,10 +56,10 @@
                         <td><?php echo $revision->getState(); ?></td>
                     </tr>
                 </table>
-                <?php if ($revision->getRevisionNr() != $this->data['latestRevisionNbr']): ?>
+                <?php if ($revision->getRevisionNr() > 0): ?>
                     <div id="compare_revisions_content_<?php echo $revision->getRevisionNr(); ?>" class="hidden compareRevisionsContent">
                         <em>
-                            <?php echo $this->t('tab_edit_entity_revision_compare') . ' (revision ' . $revision->getRevisionNr() . ' versus revision ' . ($revision->getRevisionNr() + 1) . ')'; ?>
+                            <?php echo $this->t('tab_edit_entity_revision_compare') . ' (revision ' . ($revision->getRevisionNr()-1) . ' versus revision ' . ($revision->getRevisionNr()) . ')'; ?>
                         </em>
                     </div>
                 <?php endif; ?>

--- a/www/resources/scripts/edit-entity-module.js
+++ b/www/resources/scripts/edit-entity-module.js
@@ -102,10 +102,10 @@ $(document).ready(function() {
         for (var i = startRevision; i < endRevision ; i++) {
             var d = jsondiffpatch.diff(jsonCompareRevisions[i], jsonCompareRevisions[i+1]);
             if (typeof d == 'undefined') {
-                $("#compare_revisions_content_" + i).html('<p>No changes</p>');
+                $("#compare_revisions_content_" + (i+1)).html('<p>No changes</p>');
             } else {
                 var html = jsondiffpatch.html.diffToHtml(jsonCompareRevisions[i], jsonCompareRevisions[i+1], d);
-                $("#compare_revisions_content_" + i).append(html);
+                $("#compare_revisions_content_" + (i+1)).append(html);
             }
             $('.jsondiffpatch-visualdiff-root').click(function(){
                 $(this).find('li.jsondiffpatch-unchanged').toggle();

--- a/www/resources/styles/revisions.css
+++ b/www/resources/styles/revisions.css
@@ -2,7 +2,7 @@ table.revision {
     width: 50%;
     font-size: 12px;
     border-spacing: 2px;
-    border-bottom: 2px solid #c2c2c2;
+    border: 2px solid #c2c2c2;
     line-height: 18px;
     margin-bottom: 15px;
     table-layout: fixed;
@@ -18,6 +18,11 @@ table.revision tr:nth-child(odd) {
 
 .revisionAttributes {
     width: 130px;
+}
+
+.compareRevisionsContent {
+    margin-left: 4em;
+    margin-bottom: 6pt;
 }
 
 .hidden {


### PR DESCRIPTION
This commit fixed the ordering of the revisions diffs in the editentity history screen.  Before, changes between revision 3 and 4 would be shown when looking at the detials of revision 3.  This patch fixes this, so the diff between revision 3 and 4 is shown with the details of rev 4.
