### PR TITLE
Performance improvements for arp REST call.

### DIFF
--- a/lib/DiContainer.php
+++ b/lib/DiContainer.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 use Janus\ServiceRegistry\Bundle\SSPIntegrationBundle\DependencyInjection\AuthenticationProvider;
+use Janus\ServiceRegistry\Bundle\SSPIntegrationBundle\DependencyInjection\SSPConfigFactory;
 use Janus\ServiceRegistry\Entity\User;
 
 class sspmod_janus_DiContainer extends Pimple
@@ -102,7 +103,7 @@ class sspmod_janus_DiContainer extends Pimple
      */
     public function getConfig()
     {
-        return $this->getSymfonyContainer()->get('janus_config');
+        return SSPConfigFactory::getInstance('prod');
     }
 
     /**

--- a/lib/Entity.php
+++ b/lib/Entity.php
@@ -266,9 +266,9 @@ class sspmod_janus_Entity extends sspmod_janus_Database
     private function _findEid() {
         if(isset($this->_entityid)) {
             $st = $this->execute(
-                'SELECT DISTINCT(`eid`) 
-                FROM `'. self::$prefix .'connectionRevision`
-                WHERE `entityid` = ?;',
+                'SELECT DISTINCT(`id`) AS eid 
+                FROM `'. self::$prefix .'connection`
+                WHERE `name` = ?;',
                 array($this->_entityid)
             );
 


### PR DESCRIPTION
 No longer use Symfony Container (so bootstrapping is not done for Symfony Kernel) for configuration and make use of new janus__connection table for _findEid so it can use its indexes.
