### PR TITLE
#484 Fixed showing all metadata fields

### DIFF
--- a/lib/MetadataFieldBuilder.php
+++ b/lib/MetadataFieldBuilder.php
@@ -48,7 +48,7 @@ class sspmod_janus_MetadataFieldBuilder
         foreach($this->metadataFieldConfiguration AS $fieldName => $fieldOptions) {
 
             // If supported is set, build multiple metadata fields
-            if (isset($fieldOptions['supported']) && is_array($fieldOptions['supported'])) {
+            if (!empty($fieldOptions['supported'])) {
                 $this->buildMultiSupportedFields($fieldName, $fieldOptions);
                 continue;
             }


### PR DESCRIPTION
Fixes #484 This was broken due to a check for the supported config being present, however due to the way Symfony config works it is always present but may be empty.
