### PR TITLE
Also check if a key is explicitly marked for signing before rejecting it

### DIFF
--- a/lib/Importer.php
+++ b/lib/Importer.php
@@ -211,7 +211,8 @@ class sspmod_janus_Importer
 
         foreach ($certKeys as $certKey) {
             if (isset($parsedMetaData[$certKey . 'X509Certificate']) &&
-                (!isset($parsedMetaData[$certKey . 'encryption']) ||
+                ( (isset($parsedMetaData[$certKey . 'signing']) && $parsedMetaData[$certKey . 'signing']) ||
+                    !isset($parsedMetaData[$certKey . 'encryption']) ||
                     (isset($parsedMetaData[$certKey . 'encryption']) && !$parsedMetaData[$certKey . 'encryption']) ||
                     $encryptionEnabled)) {
                 $certData = $parsedMetaData[$certKey . 'X509Certificate'];

--- a/lib/Importer.php
+++ b/lib/Importer.php
@@ -210,11 +210,15 @@ class sspmod_janus_Importer
         $certificates = array();
 
         foreach ($certKeys as $certKey) {
-            if (isset($parsedMetaData[$certKey . 'X509Certificate']) &&
-                ( (isset($parsedMetaData[$certKey . 'signing']) && $parsedMetaData[$certKey . 'signing']) ||
-                    !isset($parsedMetaData[$certKey . 'encryption']) ||
-                    (isset($parsedMetaData[$certKey . 'encryption']) && !$parsedMetaData[$certKey . 'encryption']) ||
-                    $encryptionEnabled)) {
+            if (!isset($parsedMetaData[$certKey . 'X509Certificate'])) {
+                continue;
+            }
+            if (
+                (isset($parsedMetaData[$certKey . 'signing']) && $parsedMetaData[$certKey . 'signing']) ||
+                !isset($parsedMetaData[$certKey . 'encryption']) ||
+                (isset($parsedMetaData[$certKey . 'encryption']) && !$parsedMetaData[$certKey . 'encryption']) ||
+                $encryptionEnabled
+               ) {
                 $certData = $parsedMetaData[$certKey . 'X509Certificate'];
                 /*
                  * We don't want an empty certData if keys:0 is an encryption key and encryption is not enabled. So we


### PR DESCRIPTION
If a key is marked both encryption AND signing, the test would reject it because it considered it to be an encryption key.

Fixes #570