### PR TITLE
Fix failing assert when $connectionRevisionId is integer.

### DIFF
--- a/lib/Metadata.php
+++ b/lib/Metadata.php
@@ -123,7 +123,7 @@ class sspmod_janus_Metadata extends sspmod_janus_Database
      */
     public function setConnectionRevisionId($connectionRevisionId)
     {
-        assert('ctype_digit($connectionRevisionId)');
+        assert('ctype_digit("$connectionRevisionId")');
 
         $this->_connectionRevisionId = $connectionRevisionId;
     }


### PR DESCRIPTION
On an Ubuntu 15.10 install using MariaDB $connectionRevisionIdFix turned out to be integer (causing the assert to fail). Casting to string should make it backwards compatible with previous behaviour.