### PR TITLE
Fix missing/null array2 when comparing arrays

### DIFF
--- a/templates/importentity.php
+++ b/templates/importentity.php
@@ -119,7 +119,7 @@ $this->includeAtTemplateBase('includes/header.php');
                     </tr>
                 </thead>
                 <tbody>
-                <?php foreach ($this->data['arpChanges'] as $changedKey => $changedValues): ?>
+                <?php (is_array($this->data['arpChanges'])) foreach ($this->data['arpChanges'] as $changedKey => $changedValues): ?>
                     <?php
                     $oldValues = !empty($this->data['oldArp'][$changedKey]) ? $this->data['oldArp'][$changedKey] : array();
                     ?>

--- a/www/importentity.php
+++ b/www/importentity.php
@@ -228,6 +228,7 @@ $et->show();
 
 function janus_array_diff_recursive($array1, $array2)
 {
+    if (!is_array($array2)) return $array1;
     $diff = array();
     foreach ($array1 as $key => $value) {
         if (is_array($array2) && array_key_exists($key, $array2)) {


### PR DESCRIPTION
While bootstrapping Janus with some imported metadata, janus_array_diff_recursive broke on missing/empty $array2. The result should be $array1.