### PR TITLE
Replace SimpleSAML_Sesssion::getSession()

### DIFF
--- a/www/dashboard.php
+++ b/www/dashboard.php
@@ -31,7 +31,7 @@ define('TAB_AJAX_CONTENT_PREFIX', 'ajax-content/');
 require __DIR__ . '/_includes.php';
 
 set_time_limit(180);
-$session = SimpleSAML_Session::getSession();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $config = SimpleSAML_Configuration::getInstance();
 $janus_config = sspmod_janus_DiContainer::getInstance()->getConfig();
 $csrf_provider = sspmod_janus_DiContainer::getInstance()->getCsrfProvider();

--- a/www/editentity.php
+++ b/www/editentity.php
@@ -9,7 +9,7 @@ require __DIR__ . '/_includes.php';
 // Initial import
 /** @var $session SimpleSAML_Session */
 set_time_limit(180);
-$session = SimpleSAML_Session::getSession();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $config = SimpleSAML_Configuration::getInstance();
 $janus_config = sspmod_janus_DiContainer::getInstance()->getConfig();
 

--- a/www/exportentity.php
+++ b/www/exportentity.php
@@ -10,7 +10,7 @@
 require __DIR__ . '/_includes.php';
 
 /* Load simpleSAMLphp, configuration and metadata */
-$session = SimpleSAML_Session::getSession();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $config = SimpleSAML_Configuration::getInstance();
 $janus_config = sspmod_janus_DiContainer::getInstance()->getConfig();
 

--- a/www/metadataexport.php
+++ b/www/metadataexport.php
@@ -3,7 +3,7 @@
 require __DIR__ . '/_includes.php';
 
 // Get configuration
-$session = SimpleSAML_Session::getSession();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $config = SimpleSAML_Configuration::getInstance();
 $janus_config = sspmod_janus_DiContainer::getInstance()->getConfig();
 $util = new sspmod_janus_AdminUtil();

--- a/www/noNewUser.php
+++ b/www/noNewUser.php
@@ -16,7 +16,7 @@
 
 require __DIR__ . '/_includes.php';
 
-$session = SimpleSAML_Session::getSession();
+$session = SimpleSAML_Session::getSessionFromRequest();
 $config = SimpleSAML_Configuration::getInstance();
 $janus_config = sspmod_janus_DiContainer::getInstance()->getConfig();
 


### PR DESCRIPTION
SimpleSAML_Session::getInstance() should have been replaced by SimpleSAML_Sesssion::getSessionFromRequest()

See the [deprecation notice](https://github.com/simplesamlphp/simplesamlphp/blob/simplesamlphp-1.13/lib/SimpleSAML/Session.php#L195) of SimpleSAML_Session::getInstance() and [this post](https://groups.google.com/forum/#!searchin/simplesamlphp/%22SimpleSAML_Session$3A$3AgetInstance%22%7Csort:relevance/simplesamlphp/K_Xje-CVOjg/pB56RqOkAwAJ)