### PR TITLE
Fix call to exec() to use full binary path

### DIFF
--- a/www/editentity.php
+++ b/www/editentity.php
@@ -419,12 +419,15 @@ if (!empty($_POST)) {
 
 
     // change Manipulation
-    if (isset($_POST['entity_manipulation']) && $securityContext->isGranted('changemanipulation', $entity) && !empty($_POST['entity_manipulation'])) {
+    if (isset($_POST['entity_manipulation']) && $securityContext->isGranted('changemanipulation', $entity)) {
         $manipulationCode = $_POST['entity_manipulation'];
-
-        ob_start();
-        $returnCode = eval($manipulationCode);
-        $lintOutput = ob_get_clean();
+        $returnCode = null;
+        
+        if (!empty($_POST['entity_manipulation'])) {
+            ob_start();
+            $returnCode = eval($manipulationCode);
+            $lintOutput = ob_get_clean();
+        }
         
         if ($returnCode === null) {
             if ($entity->setManipulation($manipulationCode)) {

--- a/www/editentity.php
+++ b/www/editentity.php
@@ -6,6 +6,8 @@
 
 require __DIR__ . '/_includes.php';
 
+use Symfony\Component\Process\PhpExecutableFinder;
+
 // Initial import
 /** @var $session SimpleSAML_Session */
 set_time_limit(180);
@@ -421,15 +423,19 @@ if (!empty($_POST)) {
     // change Manipulation
     if (isset($_POST['entity_manipulation']) && $securityContext->isGranted('changemanipulation', $entity)) {
         $manipulationCode = $_POST['entity_manipulation'];
+
+        $lintFile = tempnam(sys_get_temp_dir(), 'lint');
+        file_put_contents($lintFile, '<?php ' . $manipulationCode);
+
         $returnCode = null;
+        $lintOutput = null;
+
+        $binary = (new PhpExecutableFinder)->find();
+        exec("$binary -d error_reporting=E_ALL -l $lintFile", $lintOutput, $returnCode);
+
+        unlink($lintFile);
         
-        if (!empty($_POST['entity_manipulation'])) {
-            ob_start();
-            $returnCode = eval($manipulationCode);
-            $lintOutput = ob_get_clean();
-        }
-        
-        if ($returnCode === null) {
+        if ((int)$returnCode === 0) {
             if ($entity->setManipulation($manipulationCode)) {
                 markForUpdate();
                 $note .= 'Changed manipulation: ' . htmlspecialchars($_POST['entity_manipulation']) . '<br />';
@@ -437,6 +443,8 @@ if (!empty($_POST)) {
             }
         } else {
             $msg = "error_manipulation_syntax";
+            array_pop($lintOutput);
+            $lintOutput = str_replace("in $lintFile", '', implode(PHP_EOL, $lintOutput));
             $session->setData('string', 'manipulation_syntax_errors', $lintOutput);
             $session->setData('string', 'manipulation_code', $manipulationCode);
         }


### PR DESCRIPTION
I accidentally ran into this because I have php installed in a non-standard location (outside the system path). This led to 'php: command not found' errors.

The use of exec() should probably be avoided for security reasons and I think this commit is a pretty good workaround.