### PR TITLE
Fix excluded entities and metadata export warning

### DIFF
--- a/lib/AdminUtil.php
+++ b/lib/AdminUtil.php
@@ -91,6 +91,7 @@ class sspmod_janus_AdminUtil extends sspmod_janus_Database
         // Select entity (only last revision)
         $selectFields = array(
             'DISTINCT CONNECTION_REVISION.eid',
+            'CONNECTION_REVISION.entityid',
             'CONNECTION_REVISION.revisionid',
             'CONNECTION_REVISION.created',
             'CONNECTION_REVISION.state',


### PR DESCRIPTION
Entityid was not being returned by getEntitiesByStateType(), so a metadata
export generated warnings about it:

PHP Notice: Undefined index: entityid in /var/simplesamlphp/modules/janus/www/metadataexport.php on
line 265

Excluded entities didn't work at all as a side effect.