### PR TITLE
Fix array to string conversion warning when exporting metadata

### DIFF
--- a/www/metadataexport.php
+++ b/www/metadataexport.php
@@ -255,7 +255,7 @@ try {
 
     $xml->appendChild($entitiesDescriptor);
 
-    $ssp_metadata = '// Metadata for state "' . $md_options['states'] . '"';
+    $ssp_metadata = '// Metadata for state "' . implode(', ', $md_options['states']) . '"';
 
     $errors = array();
     // Process all selected entities


### PR DESCRIPTION
Combines all values into a comma-separated string