### PR TITLE
Check for the correct type on ACS-Index

### DIFF
--- a/app/config-dist/config_janus_core.yml
+++ b/app/config-dist/config_janus_core.yml
@@ -531,7 +531,7 @@ janus_service_registry_core:
                 default: 'CHANGE THIS'
                 default_allow: false
                 required: false
-                validate: isurl
+                validate: isint
                 supported:
                     - 0
             'SingleLogoutService:#:Binding':

--- a/lib/Validation/Metadata.php
+++ b/lib/Validation/Metadata.php
@@ -45,4 +45,9 @@ $functions = array(
             return (preg_match("/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/", $value) == 1);
         ',
     ),
+    'isint' => array(
+        'code' => '
+            return is_integer($value);
+        ',
+    ),
 );


### PR DESCRIPTION
This fixes 
![afbeelding](https://cloud.githubusercontent.com/assets/841045/21295836/cd8a8de6-c55d-11e6-95c2-165a899df370.png)

The PR introduces a new type-check