### PR TITLE
Produce valid PHP on application/simplesamlphp+text feeds

### DIFF
--- a/lib/MetaExport.php
+++ b/lib/MetaExport.php
@@ -122,7 +122,7 @@ class sspmod_janus_MetaExport
             $disabledConsent = $entityController->getDisableConsent();
 
             $metaFlat = '// Revision: '. $entity->getRevisionid() ."\n";
-            $metaFlat .= var_export($entityId, TRUE) . ' => ' . var_export($metaArray, TRUE) . ',';
+            $metaFlat .= '$metadata[' . var_export($entityId, TRUE) . '] = ' . var_export($metaArray, TRUE) . ';';
 
             // Add authproc filter to block blocked entities
             if (!empty($blockedEntities) || !empty($allowedEntities)) {

--- a/www/metadataexport.php
+++ b/www/metadataexport.php
@@ -255,7 +255,8 @@ try {
 
     $xml->appendChild($entitiesDescriptor);
 
-    $ssp_metadata = '// Metadata for state "' . implode(', ', $md_options['states']) . '"';
+    $ssp_metadata = "<?php\n";
+    $ssp_metadata .= '// Metadata for state "' . implode(', ', $md_options['states']) . '"';
 
     $errors = array();
     // Process all selected entities


### PR DESCRIPTION
A feed configured to use the provided application/simplesamlphp+text mime produces almost valid PHP
code, but it requires some tweaking to be used.

This PR makes it actual PHP code by adding:

- An opening '<?php' tag
- An independent '$metadata[]' assignment for every returned entity