### PR TITLE
Set proper jQuery version

### DIFF
--- a/templates/error.php
+++ b/templates/error.php
@@ -9,7 +9,7 @@
  * @version    $Id: janus-main.php 11 2009-03-27 13:51:02Z jach@wayf.dk $
  */
 $janus_config = sspmod_janus_DiContainer::getInstance()->getConfig();
-$this->data['jquery'] = array('version' => '1.6', 'core' => TRUE, 'ui' => TRUE, 'css' => TRUE);
+$this->data['jquery'] = array('version' => '1.8', 'core' => TRUE, 'ui' => TRUE, 'css' => TRUE);
 $this->data['head']  = '<link rel="stylesheet" type="text/css" href="/' . $this->data['baseurlpath'] . 'module.php/janus/resources/style.css" />' . "\n";
 
 $this->includeAtTemplateBase('includes/header.php');

--- a/templates/importentity.php
+++ b/templates/importentity.php
@@ -4,7 +4,7 @@
 
 $csrf_provider = sspmod_janus_DiContainer::getInstance()->getCsrfProvider();
 
-$this->data['jquery'] = array('version' => '1.6', 'core' => true, 'ui' => true, 'css' => true);
+$this->data['jquery'] = array('version' => '1.8', 'core' => true, 'ui' => true, 'css' => true);
 $this->data['head'] = '<link rel="stylesheet" type="text/css" href="/' . $this->data['baseurlpath'] . 'module.php/janus/resources/style.css" />' . "\n";
 $this->data['head'] = '<link rel="stylesheet" type="text/css" href="/' . $this->data['baseurlpath'] . 'module.php/janus/resources/styles/import.css" />' . "\n";
 

--- a/templates/metadataexport.php
+++ b/templates/metadataexport.php
@@ -1,6 +1,6 @@
 <?php
 $this->data['header'] = 'JANUS - ' . $this->t('title');
-//$this->data['jquery'] = array('version' => '1.6', 'core' => TRUE, 'ui' => TRUE, 'css' => TRUE);
+//$this->data['jquery'] = array('version' => '1.8', 'core' => TRUE, 'ui' => TRUE, 'css' => TRUE);
 $this->data['head']  = '<link rel="stylesheet" type="text/css" href="/' . $this->data['baseurlpath'] . 'module.php/janus/resources/style.css" />' . "\n";
 $this->includeAtTemplateBase('includes/header.php');
 $language = $this->getLanguage();

--- a/templates/metalisting.php
+++ b/templates/metalisting.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->data['jquery'] = array('version' => '1.6', 'core' => true, 'ui' => TRUE, 'css' => true);
+$this->data['jquery'] = array('version' => '1.8', 'core' => true, 'ui' => TRUE, 'css' => true);
 $this->data['head']  = '<link rel="stylesheet" type="text/css" href="/' . $this->data['baseurlpath'] . 'module.php/janus/resources/style.css" />' . "\n";
 $this->includeAtTemplateBase('includes/header.php');
 

--- a/templates/show-entities-validation.php
+++ b/templates/show-entities-validation.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->data['jquery'] = array('version' => '1.6', 'core' => true, 'ui' => true, 'css' => true);
+$this->data['jquery'] = array('version' => '1.8', 'core' => true, 'ui' => true, 'css' => true);
 $this->data['head'] = '<link rel="stylesheet" type="text/css" href="resources/styles/validate.css" />'."\n";
 $this->includeAtTemplateBase('includes/header.php');
 


### PR DESCRIPTION
Currently, jQuery cannot be loaded:
> ReferenceError: jQuery is not defined [Meer info] jquery.tmpl.min.js:10:2
> ReferenceError: $ is not defined [Meer info] validate.js:1:1

This is because SimpleSAMLphp ships with jQuery 1.8 since release 1.14